### PR TITLE
Allow other commands to be passed to the entry script, defaulting to …

### DIFF
--- a/run-docker-shell.sh
+++ b/run-docker-shell.sh
@@ -4,6 +4,12 @@
 docker volume create --name maven-build-mvn-repo
 docker volume create --name maven-build-clones
 
+cmd="$@"
+
+if [ -z "$@" ]; then
+    cmd="bash"
+fi
+
 docker run \
 	-v ~/.ssh:/mapped/.ssh \
 	-v ~/.gitconfig:/mapped/.gitconfig \
@@ -12,5 +18,5 @@ docker run \
 	-v maven-build-clones:/mapped/git-clones \
 	-e LOCAL_USER_ID=`id -u $USER` \
 	-it maven-build \
-        bash	
+        $cmd	
 


### PR DESCRIPTION
…bash.

Just an idea to allow for something like:
```
./run-docker-shell.sh cd some-project && git fetch origin && git reset --hard origin/master && mvn clean install
```